### PR TITLE
Update Footer.tsx

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -61,17 +61,17 @@ const Footer = () => {
 							<h2 className="mb-2 text-sm font-semibold  uppercase text-white">Developers</h2>
 							<ul className="text-gray-400 font-medium">
 								<li className="mb-1">
-									<Link href="https://github.com/KastelApp" className="hover:text-blue-500 hover:underline" as={NextLink}>
+									<Link href="https://github.com/KastelApp" target="_blank" className="hover:text-blue-500 hover:underline" as={NextLink}>
 										Github
 									</Link>
 								</li>
 								<li className="mb-1">
-									<Link href="/developers/docs" className="hover:text-blue-500 hover:underline" as={NextLink}>
+									<Link href="https://kastel.dev/docs" target="_blank" className="hover:text-blue-500 hover:underline" as={NextLink}>
 										Documentation
 									</Link>
 								</li>
 								<li className="mb-1">
-									<Link href="/developers/apps" className="hover:text-blue-500 hover:underline" as={NextLink}>
+									<Link href="https://kastel.dev/" target="_blank" className="hover:text-blue-500 hover:underline" as={NextLink}>
 										Bots
 									</Link>
 								</li>
@@ -114,11 +114,11 @@ const Footer = () => {
 							>
 								<path
 									fillRule="evenodd"
-									d="M20 1.892a8.178 8.178 0 0 1-2.355.635 4.074 4.074 0 0 0 1.8-2.235 8.344 8.344 0 0 1-2.605.98A4.13 4.13 0 0 0 13.85 0a4.068 4.068 0 0 0-4.1 4.038 4 4 0 0 0 .105.919A11.705 11.705 0 0 1 1.4.734a4.006 4.006 0 0 0 1.268 5.392 4.165 4.165 0 0 1-1.859-.5v.05A4.057 4.057 0 0 0 4.1 9.635a4.19 4.19 0 0 1-1.856.07 4.108 4.108 0 0 0 3.831 2.807A8.36 8.36 0 0 1 0 14.184 11.732 11.732 0 0 0 6.291 16 11.502 11.502 0 0 0 17.964 4.5c0-.177 0-.35-.012-.523A8.143 8.143 0 0 0 20 1.892Z"
+									d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"
 									clipRule="evenodd"
 								/>
 							</svg>
-							<span className="sr-only">Twitter page</span>
+							<span className="sr-only">X (Twitter) Page</span>
 						</Link>
 						<Link
 							href="https://github.com/KastelApp"
@@ -138,7 +138,7 @@ const Footer = () => {
 									clipRule="evenodd"
 								/>
 							</svg>
-							<span className="sr-only">GitHub account</span>
+							<span className="sr-only">GitHub Account</span>
 						</Link>
 					</div>
 				</div>


### PR DESCRIPTION
- Changed the docs and bots links to kastel.dev. Should we just combine those and make it "Developer Portal" like the header?
- Added new tab redirects to the developers section. All the links there go to outside websites of main site.
- Replaced the SVG of the old Twitter logo to the new X one. Also, changed the screen reader name to "X (Twitter) Page"
- Changed screen reader name from "GitHub account" to "GitHub Account"